### PR TITLE
standardize date formatting to yyyy-mm-dd across all pages

### DIFF
--- a/app/api/radar/technologies/[id]/route.ts
+++ b/app/api/radar/technologies/[id]/route.ts
@@ -2,7 +2,6 @@ import { createNeonClient } from '@/lib/db/neon';
 import { NextResponse } from 'next/server';
 import { Resend } from 'resend';
 
-const resend = new Resend(process.env.RESEND_API_KEY);
 const alertEmailTo = process.env.ALERT_EMAIL_TO;
 
 export async function PUT(request: Request, { params }: { params: { id: string } }) {
@@ -59,8 +58,9 @@ export async function PUT(request: Request, { params }: { params: { id: string }
       }
 
       // Send email alert
-      if (alertEmailTo) {
+      if (alertEmailTo && process.env.RESEND_API_KEY) {
         try {
+          const resend = new Resend(process.env.RESEND_API_KEY);
           await resend.emails.send({
             from: 'Technology Radar <no-reply@your-domain.com>', // Replace with your domain
             to: alertEmailTo,

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -57,9 +57,9 @@ export default async function Article({ params }: { params: { slug: string } }) 
       <div className="text-center">
         <h1 className="text-5xl md:text-8xl font-bold font-mono leading-[1.4] mb-4">{data.title}</h1>
         <p className="text-gray-500 mt-8 font-serif">
-          Published {new Date(data.date).toLocaleDateString()} | Updated &nbsp;
-          {data.updated ?? (
-            <span> {new Date(data.updated).toLocaleDateString()}</span>
+          Published {new Date(data.date).toISOString().split('T')[0]}
+          {data.updated && (
+            <span> | Updated {new Date(data.updated).toISOString().split('T')[0]}</span>
           )}
         </p>
         <p className="text-2xl mt-6 text-rosePineMoon-muted dark:text-rosePine-muted">&sect;</p>

--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -191,7 +191,7 @@ export default function CategoriesPage() {
                           </Link>
                           <div className="text-xs text-rosePine-subtle dark:text-rosePineMoon-subtle">
                             {item.author && <span>by {item.author} • </span>}
-                            {new Date(item.date).toLocaleDateString()}
+                            {new Date(item.date).toISOString().split('T')[0]}
                           </div>
                         </div>
                       ))}

--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -191,7 +191,7 @@ export default function CategoriesPage() {
                           </Link>
                           <div className="text-xs text-rosePine-subtle dark:text-rosePineMoon-subtle">
                             {item.author && <span>by {item.author} • </span>}
-                            {new Date(item.date).toISOString().split('T')[0]}
+                            {item.date && new Date(item.date).toISOString().split('T')[0]}
                           </div>
                         </div>
                       ))}

--- a/app/category/[category]/page.tsx
+++ b/app/category/[category]/page.tsx
@@ -131,7 +131,7 @@ export default function CategoryPage({ params }: { params: { category: string } 
               </div>
               <div className="text-sm text-rosePine-subtle dark:text-rosePineMoon-subtle">
                 {item.author && <span>by {item.author} • </span>}
-                {new Date(item.date).toISOString().split('T')[0]}
+                {item.date && new Date(item.date).toISOString().split('T')[0]}
               </div>
             </div>
           ))}

--- a/app/category/[category]/page.tsx
+++ b/app/category/[category]/page.tsx
@@ -131,7 +131,7 @@ export default function CategoryPage({ params }: { params: { category: string } 
               </div>
               <div className="text-sm text-rosePine-subtle dark:text-rosePineMoon-subtle">
                 {item.author && <span>by {item.author} • </span>}
-                {new Date(item.date).toLocaleDateString()}
+                {new Date(item.date).toISOString().split('T')[0]}
               </div>
             </div>
           ))}

--- a/app/tag/[tag]/page.tsx
+++ b/app/tag/[tag]/page.tsx
@@ -120,7 +120,7 @@ export default function TagPage({ params }: { params: { tag: string } }) {
               </div>
               <div className="text-sm text-rosePine-subtle dark:text-rosePineMoon-subtle">
                 {item.author && <span>by {item.author} • </span>}
-                {new Date(item.date).toISOString().split('T')[0]}
+                {item.date && new Date(item.date).toISOString().split('T')[0]}
               </div>
             </div>
           ))}

--- a/app/tag/[tag]/page.tsx
+++ b/app/tag/[tag]/page.tsx
@@ -120,7 +120,7 @@ export default function TagPage({ params }: { params: { tag: string } }) {
               </div>
               <div className="text-sm text-rosePine-subtle dark:text-rosePineMoon-subtle">
                 {item.author && <span>by {item.author} • </span>}
-                {new Date(item.date).toLocaleDateString()}
+                {new Date(item.date).toISOString().split('T')[0]}
               </div>
             </div>
           ))}

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -243,7 +243,7 @@ export default function TagsPage() {
                           </Link>
                           <div className="text-xs text-rosePine-subtle dark:text-rosePineMoon-subtle">
                             {item.author && <span>by {item.author} • </span>}
-                            {new Date(item.date).toLocaleDateString()}
+                            {new Date(item.date).toISOString().split('T')[0]}
                           </div>
                         </div>
                       ))}

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -243,7 +243,7 @@ export default function TagsPage() {
                           </Link>
                           <div className="text-xs text-rosePine-subtle dark:text-rosePineMoon-subtle">
                             {item.author && <span>by {item.author} • </span>}
-                            {new Date(item.date).toISOString().split('T')[0]}
+                            {item.date && new Date(item.date).toISOString().split('T')[0]}
                           </div>
                         </div>
                       ))}

--- a/ideas/the-new-technical-skill-tree.mdx
+++ b/ideas/the-new-technical-skill-tree.mdx
@@ -1,11 +1,11 @@
 ---
-    title: "The new technical skill tree"
-    date: "2026-03-24"
-    updated: "2026-03-24"
-  author: "Tyler Andor"
-    summary: "On some ways in which AI is changing the impact of certain skills in technical work"
-    categories: ["technology"]
-    tags: ["ai","technology","work","philosophy","software engineering"]
+title: "The new technical skill tree"
+date: "2026-03-24"
+updated: "2026-03-24"
+author: "Tyler Andor"
+summary: "On some ways in which AI is changing the impact of certain skills in technical work"
+categories: ["technology"]
+tags: ["ai","technology","work","philosophy","software engineering"]
 ---
 
 # The new technical skill tree


### PR DESCRIPTION
Replaces locale-dependent toLocaleDateString() with consistent ISO date format. Also fixes inverted updated-date logic on article pages (nullish coalescing → logical AND).